### PR TITLE
settting default locale for amdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,14 @@ SpreeMultiLingual depends on a fork of routing-filter because it supports :exclu
 1. Make taxons multi languages editable from the taxonomy tree
 2. Dynamically show taxon full permalink depending on dropdown language selected : Taxons#edit
 2. Travis-CI
-3. Admin default locale ?
-4. Add things to translate:
+3. Add things to translate:
 	- Option types
 	- Option values
 	- Properties
 	- Alt text on images
-5. Dropdown or something to change locale
-6. Fallback
-7. Rake task for store that already have users
+4. Dropdown or something to change locale
+5. Fallback
+6. Rake task for store that already have users
 
 ## Testing
 

--- a/app/controllers/base_controller_decorator.rb
+++ b/app/controllers/base_controller_decorator.rb
@@ -26,4 +26,11 @@ Spree::Admin::BaseController.class_eval do
     locale ||= I18n.locale
     I18n.locale == locale.to_sym ? "".to_sym : "_"+ locale
   end
+
+  private
+
+  def set_user_language
+    I18n.locale = Spree::Config[:default_locale].to_sym
+  end
+
 end


### PR DESCRIPTION
Hi Jean Philipe, I just set admin to spree's default locale to avoid conflict error when reading from resource attribute (occured for me on production).
