### PR TITLE
make the usage of the locale filter configurable

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Spree::Core::Engine.routes.draw do
-  filter :locale, :exclude => /^\/admin/
+  filter :locale, :exclude => /^\/admin/ if SpreeMultiLingual.use_locale_filter
 end

--- a/lib/spree_multi_lingual/engine.rb
+++ b/lib/spree_multi_lingual/engine.rb
@@ -1,6 +1,8 @@
 module SpreeMultiLingual
   mattr_reader :languages
+  mattr_accessor :use_locale_filter
   @@languages = [:en]
+  @@use_locale_filter = true
 
   def self.languages=(locales=[])
     I18n.available_locales = locales


### PR DESCRIPTION
Hello, in the store I'm developing we are saving the current locale using a cookie (urls are the same for all languages). I know it's a really poor approach SEO wise, but I'm sure other people must comply with silly customer requests :)

I haven't added any tests since I'd need to reload the Rails environment to rebuild the routing table. Do you have any idea how to fix this?

Thank you for your awesome project (it's a real life saver :))
