### PR TITLE
Translations for Spree::ShippingMethod, Spree::TaxRate

### DIFF
--- a/app/models/shipping_method_decorator.rb
+++ b/app/models/shipping_method_decorator.rb
@@ -1,0 +1,5 @@
+module Spree
+  ShippingMethod.class_eval do
+    translates :name
+  end
+end

--- a/app/models/tax_rate_decorator.rb
+++ b/app/models/tax_rate_decorator.rb
@@ -1,0 +1,5 @@
+module Spree
+  TaxRate.class_eval do
+    translates :name
+  end
+end

--- a/app/views/spree/order_mailer/cancel_email.fr.text.erb
+++ b/app/views/spree/order_mailer/cancel_email.fr.text.erb
@@ -1,17 +1,17 @@
 Cher client,
 
-Votre commande est annulee.
-Merci de conserver cet email pour un eventuel usage ulterieur.
+Votre commande est annulée.
+Merci de conserver ce courriel pour un éventuel usage ultérieur.
 
 ============================================================
-Commande [ANNULEE]
+Commande [ANNULÉE]
 ============================================================
 <% @order.line_items.each do |item| %>
-<%= item.variant.sku %> <%= item.variant.product.name %> <%= variant_options(item.variant) %> (<%= item.quantity %>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
+  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
 <% end %>
 ============================================================
 Sous-Total: <%= number_to_currency @order.item_total %>
-<% @order.adjustments.each do |adjustment| %>
-<%= "#{adjustment.label}: #{number_to_currency adjustment.amount}"%>
+<% @order.adjustments.eligible.each do |adjustment| %>
+  <%= raw(adjustment.label) %> <%= number_to_currency(adjustment.amount) %>
 <% end %>
-Total TTC: <%= number_to_currency @order.total %>
+Total TTC: <%= number_to_currency(@order.total) %>

--- a/app/views/spree/order_mailer/confirm_email.fr.text.erb
+++ b/app/views/spree/order_mailer/confirm_email.fr.text.erb
@@ -1,20 +1,20 @@
 Cher client,
 
-Votre commande est confirmee.
-Merci de conserver cet email pour un eventuel usage ulterieur.
+Votre commande est confirmée.
+Merci de conserver ce courriel pour un éventuel usage ultérieur.
 
 ============================================================
 Commande
 ============================================================
 <% @order.line_items.each do |item| %>
-<%=item.variant.sku %> <%=item.variant.product.name%> <%= item.variant.options_text -%> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
+  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
 <% end %>
 ============================================================
 Sous-Total: <%= number_to_currency @order.item_total %>
-<% @order.adjustments.each do |adjustment| %>
-<%= "#{adjustment.label}: #{number_to_currency adjustment.amount}"%>
+<% @order.adjustments.eligible.each do |adjustment| %>
+  <%= raw(adjustment.label) %> <%= number_to_currency(adjustment.amount) %>
 <% end %>
-Total TTC: <%= number_to_currency @order.total %>
+Total TTC: <%= number_to_currency(@order.total) %>
 
 
 Merci pour votre achat.

--- a/db/migrate/20120620153608_add_translations_to_tax_rates.rb
+++ b/db/migrate/20120620153608_add_translations_to_tax_rates.rb
@@ -1,0 +1,10 @@
+class AddTranslationsToTaxRates < ActiveRecord::Migration
+  def up
+    Spree::TaxRate.create_translation_table!({:name => :string},
+      {:migrate_data => true})
+  end
+
+  def down
+    Spree::TaxRate.drop_translation_table!(:migrate_date => true)
+  end
+end

--- a/db/migrate/20120628135204_add_translations_to_shipping_methods.rb
+++ b/db/migrate/20120628135204_add_translations_to_shipping_methods.rb
@@ -1,0 +1,9 @@
+class AddTranslationsToShippingMethods < ActiveRecord::Migration
+  def up
+    Spree::ShippingMethod.create_translation_table!(:name => :string)
+  end
+
+  def down
+    Spree::ShippingMethod.drop_translation_table!
+  end
+end


### PR DESCRIPTION
Added translations for Spree::ShippingMethod, Spree::TaxRate 

Also updated email templates to add accents but theses views are translated in next spree version so this won't be neccesary anymore, see : https://github.com/spree/spree/commit/aa7cd79ff693f6e41106489f23ada5629191a0e5
